### PR TITLE
Add BaseStore and BaseComponent. Add GitHub PRs.

### DIFF
--- a/edwin/client/static/css/client.less
+++ b/edwin/client/static/css/client.less
@@ -11,7 +11,7 @@ h1 {
     border-bottom: 1px solid #888;
     padding: 4px 5px;
     text-align: left;
-    text-weight: normal;
+    font-weight: normal;
   }
 
   &__head--number {

--- a/edwin/client/static/js/client.browserify.js
+++ b/edwin/client/static/js/client.browserify.js
@@ -12,6 +12,7 @@ import TimelineApp from './components/TimelineApp';
 import TimelineDispatcher from './dispatcher/TimelineDispatcher';
 import * as TimelineActions from './actions/TimelineActions';
 import './utils/bzAPI';
+import './utils/githubAPI';
 
 TimelineDispatcher.register((action) => {
   console.log('Dispatched action:', action);
@@ -19,4 +20,4 @@ TimelineDispatcher.register((action) => {
 
 React.render(<TimelineApp/>, document.body);
 
-TimelineActions.updateSearch({whiteboard: 's=2015.6'});
+TimelineActions.updateSearch({whiteboard: 's=2015.7'});

--- a/edwin/client/static/js/components/TimelineApp.js
+++ b/edwin/client/static/js/components/TimelineApp.js
@@ -93,7 +93,7 @@ class BugRow extends React.Component {
           {bug.getIn(['whiteboard_parsed', 'p'])}
         </td>
         <td className="BugTable__data--number">
-          {prs.map((pr) => <a href={pr.get('url')}>#{pr.get('number')}</a>)}
+          {prs.map((pr) => <a href={pr.get('html_url')}>#{pr.get('number')}</a>)}
         </td>
       </tr>
     );

--- a/edwin/client/static/js/stores/BugStore.js
+++ b/edwin/client/static/js/stores/BugStore.js
@@ -10,7 +10,7 @@ import TimelineDispatcher from '../dispatcher/TimelineDispatcher';
 import BaseStore from '../utils/BaseStore';
 import TimelineConstants from '../constants/TimelineConstants';
 import Immutable from 'immutable';
-import * as whiteboard from '../utils/parsers';
+import * as parsers from '../utils/parsers';
 
 let bugs = Immutable.List();
 
@@ -35,11 +35,7 @@ class _BugStore extends BaseStore {
  * @param {Object} bug The bug to augment. Will be modified and returned.
  */
 function augmentBug(bug) {
-  try {
-    bug.whiteboard_parsed = whiteboard.grammar.parse(bug.whiteboard);
-  } catch(e) {
-    bug.whiteboard_parsed = null;
-  }
+  bug.whiteboard_parsed = parsers.whiteboardData.parse(bug.whiteboard);
   return bug;
 }
 

--- a/edwin/client/static/js/stores/test/BugToPRStore-tests.js
+++ b/edwin/client/static/js/stores/test/BugToPRStore-tests.js
@@ -14,6 +14,16 @@ describe('PRStore', () => {
     BugToPRStore = require('../BugToPRStore');
     TimelineDispatcher = require('../../dispatcher/TimelineDispatcher');
     TimelineConstants = require('../../constants/TimelineConstants');
+
+    // Empty the stores
+    TimelineDispatcher.dispatch({
+      type: TimelineConstants.SET_RAW_BUGS,
+      newBugs: [],
+    });
+    TimelineDispatcher.dispatch({
+      type: TimelineConstants.SET_RAW_PRS,
+      newPRs: [],
+    });
   });
 
   it('makes a mapping from PRs to Bugs', () => {
@@ -21,14 +31,14 @@ describe('PRStore', () => {
       type: TimelineConstants.SET_RAW_BUGS,
       newBugs: [{id: 0, whiteboard: ''}, {id: 1, whiteboard: ''}],
     });
-    let prs = [{id: 0, title: '[Bug 0] Bar'}, {id: 1, title: '[Bug 1] Foo'}];
+    let prs = [{number: 0, title: '[Bug 0] Bar'}, {number: 1, title: '[Bug 1] Foo'}];
     TimelineDispatcher.dispatch({
       type: TimelineConstants.SET_RAW_PRS,
       newPRs: prs,
     });
 
-    expect(BugToPRStore.prsFor(0)).to.equal(Immutable.fromJS([prs[0]]));
-    expect(BugToPRStore.prsFor(1)).to.equal(Immutable.fromJS([prs[1]]));
+    expect(BugToPRStore.get(0)).to.equal(Immutable.fromJS([prs[0]]));
+    expect(BugToPRStore.get(1)).to.equal(Immutable.fromJS([prs[1]]));
   });
 
   it('returns an empty list for known bugs with no PRs', () => {
@@ -36,12 +46,32 @@ describe('PRStore', () => {
       type: TimelineConstants.SET_RAW_BUGS,
       newBugs: [{id: 0, whiteboard: ''}, {id: 1, whiteboard: ''}],
     });
+
+    expect(BugToPRStore.get(0)).to.equal(new Immutable.List());
+    expect(BugToPRStore.get(1)).to.equal(new Immutable.List());
+  });
+
+  it('returns an empty list for unknown bugs', () => {
+    expect(BugToPRStore.get(0)).to.equal(new Immutable.List());
+    expect(BugToPRStore.get(1)).to.equal(new Immutable.List());
+  });
+
+  it('returns the entire mapping', () => {
+    TimelineDispatcher.dispatch({
+      type: TimelineConstants.SET_RAW_BUGS,
+      newBugs: [{id: 0, whiteboard: ''}, {id: 1, whiteboard: ''}],
+    });
+    let prs = [{number: 0, title: '[Bug 0] Bar'}, {number: 1, title: '[Bug 1] Foo'}];
     TimelineDispatcher.dispatch({
       type: TimelineConstants.SET_RAW_PRS,
-      newPRs: [],
+      newPRs: prs,
     });
 
-    expect(BugToPRStore.prsFor(0)).to.equal(new Immutable.List());
-    expect(BugToPRStore.prsFor(1)).to.equal(new Immutable.List());
+    let expected = new Immutable.Map().withMutations((map) => {
+      map.set(0, Immutable.fromJS([prs[0]]));
+      map.set(1, Immutable.fromJS([prs[1]]));
+    });
+
+    expect(BugToPRStore.getAll()).to.equal(expected);
   });
 });

--- a/edwin/client/static/js/stores/test/PRStore-tests.js
+++ b/edwin/client/static/js/stores/test/PRStore-tests.js
@@ -14,11 +14,11 @@ describe('PRStore', () => {
   it('recieves PR data', () => {
     TimelineDispatcher.dispatch({
       type: TimelineConstants.SET_RAW_PRS,
-      newPRs: [{id: 1, title: ''}, {id: 2, title: ''}],
+      newPRs: [{number: 1, title: ''}, {number: 2, title: ''}],
     });
     let prs = PRStore.getAll();
-    expect(prs.getIn([0, 'id'])).to.equal(1);
-    expect(prs.getIn([1, 'id'])).to.equal(2);
+    expect(prs.getIn([0, 'number'])).to.equal(1);
+    expect(prs.getIn([1, 'number'])).to.equal(2);
   });
 
   it('augments PRs without bug references with an empty list', () => {

--- a/edwin/client/static/js/utils/bzAPI.js
+++ b/edwin/client/static/js/utils/bzAPI.js
@@ -7,6 +7,7 @@ import {buildUrl} from '../utils/urls';
 const fetch = window.fetch;
 const BUGZILLA_API = 'https://bugzilla.mozilla.org/rest';
 const fields = [
+  'assigned_to',
   'blocks',
   'depends_on',
   'id',
@@ -58,9 +59,6 @@ export function getBugs() {
 
   apiCall('/bug', params.toJS())
     .then((response) => response.json())
-    .catch((err) => {
-      console.error('Error fetching bugs', err);
-    })
     .then((data) => TimelineActions.setBugs(data.bugs))
     .catch((err) => {
       console.error('Error updating bugs', err);

--- a/edwin/client/static/js/utils/githubAPI.js
+++ b/edwin/client/static/js/utils/githubAPI.js
@@ -43,10 +43,10 @@ function apiCall(endpoint, params={}) {
 export function getPRs() {
   let bugs = BugStore.getAll();
 
-  apiCall(`/${REPO}/pulls`)
+  apiCall(`/repos/${REPO}/pulls`)
     .then((response) => response.json())
-    .catch((err) => {
-      console.error('Error fetching PRs', err);
+    .then((data) => {
+      return data;
     })
     .then((data) => TimelineActions.setPRs(data))
     .catch((err) => {
@@ -55,4 +55,4 @@ export function getPRs() {
 }
 
 
-QueryStore.addChangeListener(getPRs);
+BugStore.addChangeListener(getPRs);

--- a/edwin/client/static/js/utils/parsers.js
+++ b/edwin/client/static/js/utils/parsers.js
@@ -28,6 +28,7 @@ export const whiteboardData = PEG.buildParser(`
   tokens
     = token:token " "* tokens:tokens { return merge(token, tokens) }
     / token:token { return token }
+    / "" { return {} }
 
   token
     = name:ident "=" value:value? {
@@ -47,7 +48,7 @@ export const whiteboardData = PEG.buildParser(`
   value
     = int:[0-9]+ "." frac:[0-9]+ { return parseFloat(int.join('') + '.' + frac.join('')) }
     / digits:[0-9]+ { return parseInt(digits.join(''), 10); }
-    / ident
+    / chars:[a-zA-Z0-9._?-]+ { return chars.join('') }
 `);
 
 

--- a/edwin/client/static/js/utils/test/parsers-tests.js
+++ b/edwin/client/static/js/utils/test/parsers-tests.js
@@ -24,6 +24,10 @@ describe('whiteboardData', () => {
       expect(whiteboardData.parse('[foo bar] [baz]')).to.deep.equal({'foo bar': true, baz: true});
     });
 
+    it('parses p=?', () => {
+      expect(whiteboardData.parse('p=?')).to.deep.equal({'p': '?'});
+    });
+
     it('parses mixed items', () => {
       expect(whiteboardData.parse('u=dev c=user [good first bug] s=2015.6 p=2 [need-verify]'))
         .to.deep.equal({
@@ -46,24 +50,28 @@ describe('bugReferences', () => {
       bugReferences = require('../parsers').bugReferences;
     });
 
-    it('parses a line with no refs.', () => {
+    it('parses a line with no refs', () => {
       expect(bugReferences.parse('Fix the foo.')).to.deep.equal([]);
     });
 
-    it('parses a simple bug ref.', () => {
+    it('parses a simple bug ref', () => {
       expect(bugReferences.parse('[Bug 123] Fix the foo.')).to.deep.equal([123]);
     });
 
-    it('parses a double bug ref.', () => {
+    it('parses a double bug ref', () => {
       expect(bugReferences.parse('[Bug 123, 456] Fix the foo.')).to.deep.equal([123, 456]);
     });
 
-    it('parses two bug refs.', () => {
+    it('parses two bug refs', () => {
       expect(bugReferences.parse('[Bug 123][Bug 456] Fix the foo.')).to.deep.equal([123, 456]);
     });
 
-    it('parses a complex set of bug refs.', () => {
+    it('parses a complex set of bug refs', () => {
       expect(bugReferences.parse('[Bug 123,456][Bug 789] Fix the foo.')).to.deep.equal([123, 456, 789]);
+    });
+
+    it('returns integers', () => {
+      expect(bugReferences.parse('[Bug 123] Fix it.')[0]).to.be.a('number');
     });
   });
 });


### PR DESCRIPTION
This is pretty big, and wandered a bit, unfortunately.

I added a new store to correlate bug and PR data. I'm not 100% sure this is the best way to approach it, but it seems to work.

I added a BaseStore and a BaseComponent to factor some common behavior.

I also struggled a bunch with Immutable.js. I think I'm getting the hang of it. Going forward, I think that that all data that comes _out_ of the stores should be Immutable.js objects, but all other data in the system should be normal JS objects. I think that means that the components only deal in Immutable objects too. That's good, later we can use it to make the UI go super fast. The stores are the place where native JS objects become Immutable JS objects.

I've maintained, I think, pretty good test coverage. It has been useful. I'd like to explore how to test the components.
