### PR TITLE
Utils: Support list of values when building urls.

### DIFF
--- a/edwin/client/static/js/utils/test/urls-test.js
+++ b/edwin/client/static/js/utils/test/urls-test.js
@@ -17,5 +17,10 @@ describe('urls', () => {
       let url = buildUrl('http://example.com', '/api', {foo: 'bar'});
       expect(url).to.equal('http://example.com/api?foo=bar');
     });
+
+    it('allows lists of values in querystrings', () => {
+      let url = buildUrl('https://example.com', '/api', {foo: ['bar', 'baz']});
+      expect(url).to.equal('https://example.com/api?foo=bar&foo=baz');
+    });
   });
 });

--- a/edwin/client/static/js/utils/urls.js
+++ b/edwin/client/static/js/utils/urls.js
@@ -1,5 +1,13 @@
 import _ from 'lodash';
 
+function qsValue(key, value) {
+  if (Array.isArray(value)) {
+    return value.map((v) => qsValue(key, v)).join('&');
+  } else {
+    return `${key}=${value}`;
+  }
+}
+
 /**
  * @param {string} base Base of the url, such as 'http://example.com/api'
  * @param {string} endpoint Endpoint of the url, such as "/book/create".
@@ -8,7 +16,7 @@ import _ from 'lodash';
  */
 export function buildUrl(base, endpoint, query={}) {
   let qs = '';
-  let qsParts = _.map(query, (value, key) => `${key}=${value}`);
+  let qsParts = _.map(query, (value, key) => qsValue(key, value));
 
   if (qsParts.length > 0) {
     qs = '?' + qsParts.join('&');


### PR DESCRIPTION
This will come in handy with the Bugzilla API, since it allows this kind
of URL to mean an "OR" over a value.

r?
