### PR TITLE
URL Routing and multiple teams

### DIFF
--- a/edwin/client/static/css/client.less
+++ b/edwin/client/static/css/client.less
@@ -2,9 +2,11 @@ body {
   background: #f2f2f2;
   font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
   font-size: 14px;
+  margin: 0;
+  padding: 0;
 }
 
-.TimelineApp {
+.App {
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -19,6 +21,34 @@ a:hover,
 a:active {
   color: #2CA4BF;
   text-decoration: underline;
+}
+
+.Header {
+  background: #2CA4BF;
+  margin-bottom: 8px;
+  width: 100%;
+
+  & header {
+    max-width: 860px;
+    margin: auto;
+
+    nav {
+      a {
+        color: #000;
+        margin: 0 8px;
+
+        &:hover {
+          font-weight: bold;
+          text-decoration: none;
+          margin: 0 7px;
+        }
+
+        &.active {
+          font-weight: bold;
+        }
+      }
+    }
+  }
 }
 
 .BugTable {

--- a/edwin/client/static/js/actions/TimelineActions.js
+++ b/edwin/client/static/js/actions/TimelineActions.js
@@ -26,9 +26,25 @@ export function setBugs(newBugs) {
 }
 
 
+/**
+ * Replace the current set of PRs with `newPRs`, which are raw from the API.
+ * @param {Array} newPRs PR descriptions from the GitHub API.
+ */
 export function setPRs(newPRs) {
   TimelineDispatcher.dispatch({
     type: TimelineConstants.ActionTypes.SET_RAW_PRS,
     newPRs,
+  });
+}
+
+
+/**
+ * Replace the current set of Teams with `newTeams`, which are raw from the API.
+ * @param {Array} newTeams Team descriptions from the Edwin API.
+ */
+export function setTeams(newTeams) {
+  TimelineDispatcher.dispatch({
+    type: TimelineConstants.ActionTypes.SET_RAW_TEAMS,
+    newTeams,
   });
 }

--- a/edwin/client/static/js/client.browserify.js
+++ b/edwin/client/static/js/client.browserify.js
@@ -8,15 +8,31 @@
  */
 
 import React from 'react';
-import TimelineApp from './components/TimelineApp';
+import * as Router from 'react-router';
+const {Route, DefaultRoute} = Router;
+
 import TimelineDispatcher from './dispatcher/TimelineDispatcher';
 import * as TimelineActions from './actions/TimelineActions';
-import './utils/bzAPI';
-import './utils/githubAPI';
+
+import App from './components/App';
+import Welcome from './components/Welcome';
+import TeamList from './components/TeamList';
+import Timeline from './components/Timeline';
 
 TimelineDispatcher.register((action) => {
-  console.log('Dispatched action:', action);
+  console.debug('Dispatched action:', action);
 });
 
+let routes = (
+  <Route handler={App}>
+    <DefaultRoute name="home" handler={Welcome}/>
+    <Route name="team-list" path="t" handler={TeamList}/>
+    <Route name="timeline" path="t/:team" handler={Timeline}/>
+  </Route>
+);
+
 TimelineActions.updateSearch({'comment_tag': 'edwin-sumo'});
-React.render(<TimelineApp/>, document.body);
+
+Router.run(routes, Router.HashLocation, (Root) => {
+  React.render(<Root/>, document.body);
+});

--- a/edwin/client/static/js/components/App.js
+++ b/edwin/client/static/js/components/App.js
@@ -1,0 +1,35 @@
+import React from 'react';
+import * as Router from 'react-router';
+
+let {Link, RouteHandler} = Router;
+
+/**
+ * Wrapper for the rest of the app.
+ * @class
+ * @prop {Component} The UI to render. Provided by the router.
+ */
+export default class App extends React.Component {
+  render() {
+    return (
+      <div className="App">
+        <Navigation/>
+        <RouteHandler/>
+      </div>
+    );
+  }
+}
+
+class Navigation {
+  render() {
+    return (
+      <div className="Header">
+        <header>
+          <nav>
+            <Link to="home">Edwin</Link>
+            <Link to="team-list">Teams</Link>
+          </nav>
+        </header>
+      </div>
+    );
+  }
+}

--- a/edwin/client/static/js/components/TeamList.js
+++ b/edwin/client/static/js/components/TeamList.js
@@ -1,14 +1,48 @@
 import React from 'react';
+import Router from 'react-router';
+
+import ControllerComponent from '../utils/ControllerComponent';
+import * as edwinAPI from '../utils/edwinAPI';
+import TeamStore from '../stores/TeamStore';
+
+const {Link} = Router;
 
 /**
  * Shows a list of teams.
  * @class
  */
-export default class TeamList extends React.Component {
+export default class TeamList extends ControllerComponent {
+  get stores() {
+    return [TeamStore];
+  }
+
+  getNewState() {
+    return {
+      teams: TeamStore.getAll(),
+    };
+  }
+
+  /**
+   * On mounting, fetch data from APIs.
+   */
+  componentDidMount() {
+    super.componentDidMount();
+    edwinAPI.getTeams();
+  }
+
   render() {
     return (
       <div className="Welcome">
-        <h1>Teams go here</h1>
+        <h1>Teams</h1>
+        <ul>
+          {this.state.teams.map((team) => (
+            <li key={`team-${team.slug}`}>
+              <Link to="timeline" params={{team: team.get('slug')}}>
+                {team.get('name')}
+              </Link>
+            </li>
+          ))}
+        </ul>
       </div>
     );
   }

--- a/edwin/client/static/js/components/TeamList.js
+++ b/edwin/client/static/js/components/TeamList.js
@@ -1,0 +1,15 @@
+import React from 'react';
+
+/**
+ * Shows a list of teams.
+ * @class
+ */
+export default class TeamList extends React.Component {
+  render() {
+    return (
+      <div className="Welcome">
+        <h1>Teams go here</h1>
+      </div>
+    );
+  }
+}

--- a/edwin/client/static/js/components/Timeline.js
+++ b/edwin/client/static/js/components/Timeline.js
@@ -45,7 +45,7 @@ export default class TimelineApp extends ControllerComponent {
         <div>
           {undoneBugs.count()} undone bugs shown. {doneBugs.count()} done bugs not shown.
         </div>
-        <BugTable bugs={undoneBugs}/>;
+        <BugTable bugs={undoneBugs}/>
       </div>
     );
   }

--- a/edwin/client/static/js/components/Welcome.js
+++ b/edwin/client/static/js/components/Welcome.js
@@ -1,0 +1,15 @@
+import React from 'react';
+
+/**
+ * Wrapper for the rest of the app.
+ * @class
+ */
+export default class Welcome extends React.Component {
+  render() {
+    return (
+      <div className="Welcome">
+        <h1>Oh hai!</h1>
+      </div>
+    );
+  }
+}

--- a/edwin/client/static/js/constants/TimelineConstants.js
+++ b/edwin/client/static/js/constants/TimelineConstants.js
@@ -5,8 +5,10 @@ export const ActionTypes = constantMap([
   'UPDATE_SEARCH',
   /* Reset all the bugs in the store to the provided raw bugs. */
   'SET_RAW_BUGS',
-  /* Reset all the PRs in the store to the provided raw bugs. */
+  /* Reset all the PRs in the store to the provided raw prs. */
   'SET_RAW_PRS',
+  /* Reset all the teams in the store to the provided raw teams. */
+  'SET_RAW_TEAMS',
 ]);
 
 export const BugStates = constantMap([

--- a/edwin/client/static/js/stores/BugStore.js
+++ b/edwin/client/static/js/stores/BugStore.js
@@ -3,7 +3,8 @@
  *
  * Action responses:
  * - SET_RAW_BUGS: Replaces the bug state with new bugs. These bugs will be
- * 	 processed to add calculated fields.
+ * 	 processed to add calculated fields, including PR references.
+ * - SET_RAW_PRS: Wait for PRStore, and then update PR references.
  */
 
 import Immutable from 'immutable';

--- a/edwin/client/static/js/stores/PRStore.js
+++ b/edwin/client/static/js/stores/PRStore.js
@@ -2,7 +2,9 @@
  * PRStore holds the state of all the GitHub pull requests in the system.
  *
  * Action responses:
- * - SET_RAW_PRS: Replaces the PR state with new PRs.
+ * - SET_RAW_PRS: Replaces the PR state with new PRs, and then update PR
+ *   references.
+ * - SET_RAW_BUGS: Wait for BugStore, and then update PR references..
  */
 
 import Immutable from 'immutable';

--- a/edwin/client/static/js/stores/TeamStore.js
+++ b/edwin/client/static/js/stores/TeamStore.js
@@ -1,0 +1,40 @@
+/**
+ * TeamStore holds the state of all the Edwin teams in the system.
+ *
+ * Action responses:
+ * - SET_RAW_TEAMS: Replaces the PR state with new PRs.
+ */
+
+import Immutable from 'immutable';
+
+import TimelineDispatcher from '../dispatcher/TimelineDispatcher';
+import BaseStore from '../utils/BaseStore';
+import * as TimelineConstants from '../constants/TimelineConstants';
+
+let teams = Immutable.List();
+
+class _TeamStore extends BaseStore {
+  /**
+   * Get the current state of all PRs.
+   * @returns {Immutable.List} A list of all PRs.
+   */
+  getAll() {
+    return teams;
+  }
+}
+
+const TeamStore = new _TeamStore();
+
+TeamStore.dispatchToken = TimelineDispatcher.register((action) => {
+  switch(action.type) {
+    case TimelineConstants.ActionTypes.SET_RAW_TEAMS:
+      teams = Immutable.fromJS(action.newTeams);
+      TeamStore.emitChange();
+      break;
+
+    default:
+      // do nothing
+  }
+});
+
+export default TeamStore;

--- a/edwin/client/static/js/utils/edwinAPI.js
+++ b/edwin/client/static/js/utils/edwinAPI.js
@@ -6,17 +6,15 @@ import BugStore from '../stores/BugStore';
 import {buildUrl} from '../utils/urls';
 
 const fetch = window.fetch;
-const GITHUB_API = 'https://api.github.com';
-const REPO = 'mozilla/kitsune';
 
 /**
- * Make a call to the Github API.
- * @param {string} endpoint Endpoint to call, like '/repos'. Include a leading "/".
+ * Make a call to the Edwin API.
+ * @param {string} endpoint Endpoint to call, like '/teams/'. Include a leading "/".
  * @param {Object} [params={}] Params to serialize into the querystring.
  * @returns {Promise.} A promise for a Fetch Response.
  */
 function apiCall(endpoint, params={}) {
-  let url = buildUrl(GITHUB_API, endpoint, params);
+  let url = buildUrl('/api', endpoint, params);
   return fetch(url, {
     headers: {
       'Accept': 'application/json',
@@ -36,22 +34,22 @@ function apiCall(endpoint, params={}) {
 
 
 /**
- * Get PRs from GitHub and dispatch an action with the new PRs when the result
- * comes back.
+ * Get bugs from Bugzilla using the current state of the QueryStore, and
+ * dispatch an action with the new bugs when the result comes back.
  */
-export function getPRs() {
+export function getTeams() {
   let bugs = BugStore.getAll();
 
-  apiCall(`/repos/${REPO}/pulls`)
+  apiCall('/teams/')
     .then((response) => response.json())
     .then((data) => {
       return data;
     })
-    .then((data) => TimelineActions.setPRs(data))
+    .then((data) => TimelineActions.setTeams(data))
     .catch((err) => {
-      console.error('Error updating PRs', err);
+      console.error('Error updating Teams', err);
     });
 }
 
 
-export default {getPRs};
+export default {getTeams};

--- a/edwin/settings.py
+++ b/edwin/settings.py
@@ -124,6 +124,7 @@ class Base(ConstantSettings):
 class Dev(Base):
     DEBUG = True
     SECRET_KEY = 'not a secret'
+    PIPELINE_BROWSERIFY_ARGUMENTS = '-t babelify -d'
 
 
 class Test(Base):

--- a/edwin/teams/api.py
+++ b/edwin/teams/api.py
@@ -13,3 +13,4 @@ class TeamSerializer(serializers.HyperlinkedModelSerializer):
 class TeamViewSet(viewsets.ModelViewSet):
     queryset = Team.objects.order_by('pk').all()
     serializer_class = TeamSerializer
+    lookup_field = 'slug'

--- a/edwin/teams/tests/test_api.py
+++ b/edwin/teams/tests/test_api.py
@@ -49,7 +49,7 @@ class APITestCase(TestCase):
     def test_single_team(self):
         team1 = Team.objects.create(name='awesome', slug='awesome', current_burn_rate=10)
 
-        resp = self.client.get(reverse('teams:team-detail', args=(team1.pk,)))
+        resp = self.client.get(reverse('teams:team-detail', args=(team1.slug,)))
         self.assertEquals(resp.status_code, 200)
         self.assertEquals(
             json.loads(smart_text(resp.content)),

--- a/edwin/teams/urls.py
+++ b/edwin/teams/urls.py
@@ -9,5 +9,5 @@ router.register(r'teams', api.TeamViewSet)
 
 
 urlpatterns = [
-    url(r'', include(router.urls)),
+    url(r'/', include(router.urls)),
 ]

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "pegjs": "^0.8.0",
     "react": "^0.13.1",
     "react-gravatar": "^1.1.0",
+    "react-router": "^0.13.3",
     "superagent": "^1.1.0",
     "whatwg-fetch": "^0.7.0"
   },


### PR DESCRIPTION
This adds the ability for the front end to react to different URLs. Right now it uses hash based URLs, but I'd like to eventually make the backend smart enough to use non-hash based URLs.

This doesn't make the UI react to different teams yet. `/#/t/sumo` is the same content as `/#/t/asdfasfd`.
