### PR TITLE
Update most imports to pull from index.js modules.

### DIFF
--- a/edwin/client/static/js/actions/ProgressActions.js
+++ b/edwin/client/static/js/actions/ProgressActions.js
@@ -1,8 +1,8 @@
 import Immutable from 'immutable';
 
 import Dispatcher from '../dispatcher';
-import ProgressActionTypes from '../constants/ProgressActionTypes.js';
-import ProgressStore from '../stores/ProgressStore.js';
+import {ProgressActionTypes} from '../constants/';
+import {ProgressStore} from '../stores/';
 
 export function startTask(taskName) {
   Dispatcher.dispatch({

--- a/edwin/client/static/js/actions/TimelineActions.js
+++ b/edwin/client/static/js/actions/TimelineActions.js
@@ -1,16 +1,10 @@
 import Immutable from 'immutable';
 
 import Dispatcher from '../dispatcher';
-import TimelineActionTypes from '../constants/TimelineActionTypes.js';
-import bzAPI from '../utils/bzAPI';
-import githubAPI from '../utils/githubAPI.js';
-import edwinAPI from '../utils/edwinAPI.js';
-import BugStore from '../stores/BugStore.js';
-import TeamStore from '../stores/TeamStore.js';
-import UserStore from '../stores/UserStore.js';
-import PromiseExt from '../utils/PromiseExt.js';
-import ProgressActions from '../actions/ProgressActions.js';
-import BugStates from '../constants/BugStates.js';
+import {ProgressActions} from '../actions/';
+import {BugStates, TimelineActionTypes} from '../constants/';
+import {BugStore, TeamStore, UserStore} from '../stores/';
+import {bzAPI, githubAPI, edwinAPI, PromiseExt} from '../utils/';
 
 /**
  * Fetch bugs from the API, and dispatch an event to replace the bugs

--- a/edwin/client/static/js/actions/UserActions.js
+++ b/edwin/client/static/js/actions/UserActions.js
@@ -1,12 +1,10 @@
 import Immutable from 'immutable';
 
 import Dispatcher from '../dispatcher';
-import UserActionTypes from '../constants/UserActionTypes.js';
-import UserStore from '../stores/UserStore.js';
-import bzAPI from '../utils/bzAPI';
-import Cacher from '../utils/Cacher.js';
-import ProgressActions from '../actions/ProgressActions.js';
-
+import {ProgressActions} from '../actions/';
+import {UserActionTypes} from '../constants/';
+import {UserStore} from '../stores/';
+import {bzAPI, Cacher} from '../utils/';
 
 export function login(username, apiKey) {
   Dispatcher.dispatch({

--- a/edwin/client/static/js/actions/index.js
+++ b/edwin/client/static/js/actions/index.js
@@ -1,0 +1,9 @@
+import ProgressActions from './ProgressActions.js';
+import TimelineActions from './TimelineActions.js';
+import UserActions from './UserActions.js';
+
+export {
+  ProgressActions,
+  TimelineActions,
+  UserActions
+};

--- a/edwin/client/static/js/client.browserify.js
+++ b/edwin/client/static/js/client.browserify.js
@@ -9,12 +9,8 @@ import * as Router from 'react-router';
 const {Route, DefaultRoute} = Router;
 
 import Dispatcher from './dispatcher';
-import * as TimelineActions from './actions/TimelineActions';
-
-import App from './components/App';
-import Welcome from './components/Welcome';
-import TeamList from './components/TeamList';
-import Timeline from './components/Timeline';
+import {TimelineActions} from './actions/';
+import {App, Welcome, TeamList, Timeline} from './components/';
 
 let routes = (
   <Route handler={App}>

--- a/edwin/client/static/js/components/TeamList.js
+++ b/edwin/client/static/js/components/TeamList.js
@@ -1,13 +1,12 @@
 import React from 'react';
 import Router from 'react-router';
 
-import ControllerComponent from '../utils/ControllerComponent';
-import Data from './Data';
-import * as edwinAPI from '../utils/edwinAPI';
-import TeamStore from '../stores/TeamStore';
-import TimelineActions from '../actions/TimelineActions.js';
-
 const {Link} = Router;
+
+import {Data} from './';
+import {ControllerComponent, edwinAPI} from '../utils/';
+import {TeamStore} from '../stores/';
+import {TimelineActions} from '../actions/';
 
 /**
  * Shows a list of teams.

--- a/edwin/client/static/js/components/Timeline.js
+++ b/edwin/client/static/js/components/Timeline.js
@@ -3,20 +3,11 @@ import Gravatar from 'react-gravatar';
 import Immutable from 'immutable';
 import cx from 'classnames';
 
-import ControllerComponent from '../utils/ControllerComponent';
-import Data from './Data';
-import BugStore from '../stores/BugStore';
-import ProgressStore from '../stores/ProgressStore';
-import PRStore from '../stores/PRStore';
-import TeamStore from '../stores/TeamStore';
-import UserActions from '../actions/UserActions.js';
-import UserStore from '../stores/UserStore.js';
-import BugStates from '../constants/BugStates.js';
-import TimelineActions from '../actions/TimelineActions.js';
-import ProgressActions from '../actions/ProgressActions.js';
-import Cacher from '../utils/Cacher.js';
-import edwinAPI from '../utils/edwinAPI.js';
-import Icon from './Icon.js';
+import {Data, Icon} from './';
+import {ProgressActions, TimelineActions, UserActions} from '../actions/';
+import {BugStates} from '../constants/';
+import {BugStore, ProgressStore, PRStore, TeamStore, UserStore} from '../stores/';
+import {ControllerComponent, Cacher, edwinAPI} from '../utils/';
 
 /**
  * Renders most of the bug UI. Should contain the Queue, Ready, and Not Ready

--- a/edwin/client/static/js/components/UserManager.js
+++ b/edwin/client/static/js/components/UserManager.js
@@ -1,12 +1,10 @@
 import React from 'react';
 import Immutable from 'immutable';
 
-import ControllerComponent from '../utils/ControllerComponent';
-import UserStore from '../stores/UserStore';
-import UserActions from '../actions/UserActions.js';
-import Icon from './Icon.js';
-import Cacher from '../utils/Cacher.js';
-
+import {Icon} from './';
+import {UserActions} from '../actions/';
+import {UserStore} from '../stores/';
+import {Cacher, ControllerComponent} from '../utils/';
 
 export default class UserManager extends ControllerComponent {
   get stores() {

--- a/edwin/client/static/js/components/index.js
+++ b/edwin/client/static/js/components/index.js
@@ -1,0 +1,17 @@
+import App from './App.js';
+import Data from './Data.js';
+import Icon from './Icon.js';
+import TeamList from './TeamList.js';
+import Timeline from './Timeline.js';
+import UserManager from './UserManager.js';
+import Welcome from './Welcome.js';
+
+export {
+  App,
+  Data,
+  Icon,
+  TeamList,
+  Timeline,
+  UserManager,
+  Welcome
+};

--- a/edwin/client/static/js/constants/index.js
+++ b/edwin/client/static/js/constants/index.js
@@ -1,0 +1,11 @@
+import BugStates from './BugStates.js';
+import ProgressActionTypes from './ProgressActionTypes.js';
+import TimelineActionTypes from './TimelineActionTypes.js';
+import UserActionTypes from './UserActionTypes.js';
+
+export {
+  BugStates,
+  ProgressActionTypes,
+  TimelineActionTypes,
+  UserActionTypes
+};

--- a/edwin/client/static/js/stores/BugStore.js
+++ b/edwin/client/static/js/stores/BugStore.js
@@ -11,12 +11,13 @@ import Immutable from 'immutable';
 import toposort from 'toposort';
 
 import Dispatcher from '../dispatcher.js';
-import BaseStore from '../utils/BaseStore.js';
-import PRStore from './PRStore.js';
-import TeamStore from './TeamStore.js';
-import TimelineActionTypes from '../constants/TimelineActionTypes.js';
-import BugStates from '../constants/BugStates.js';
+import {TeamStore} from './';
+import {BugStates, TimelineActionTypes} from '../constants/';
 import {whiteboardData} from '../utils/parsers.js';
+
+// For some reason, these can't use the normal import pattern.
+import BaseStore from '../utils/BaseStore';
+import PRStore from './PRStore.js';
 
 let bugMap = Immutable.OrderedMap();
 

--- a/edwin/client/static/js/stores/PRStore.js
+++ b/edwin/client/static/js/stores/PRStore.js
@@ -10,10 +10,12 @@
 import Immutable from 'immutable';
 
 import Dispatcher from '../dispatcher';
-import BaseStore from '../utils/BaseStore';
-import BugStore from './BugStore';
-import TimelineActionTypes from '../constants/TimelineActionTypes.js';
+import {BugStore} from './';
+import {TimelineActionTypes} from '../constants/';
 import {bugReferences} from '../utils/parsers';
+
+// For some reason, this can't use the normal import pattern.
+import BaseStore from '../utils/BaseStore';
 
 let prs = Immutable.List();
 

--- a/edwin/client/static/js/stores/ProgressStore.js
+++ b/edwin/client/static/js/stores/ProgressStore.js
@@ -6,8 +6,10 @@
 import Immutable from 'immutable';
 
 import Dispatcher from '../dispatcher';
+import {ProgressActionTypes} from '../constants/';
+
+// For some reason, this can't use the normal import pattern.
 import BaseStore from '../utils/BaseStore';
-import ProgressActionTypes from '../constants/ProgressActionTypes.js';
 
 let storeData = new Immutable.Map();
 

--- a/edwin/client/static/js/stores/TeamStore.js
+++ b/edwin/client/static/js/stores/TeamStore.js
@@ -8,8 +8,10 @@
 import Immutable from 'immutable';
 
 import Dispatcher from '../dispatcher';
-import BaseStore from '../utils/BaseStore';
-import TimelineActionTypes from '../constants/TimelineActionTypes.js';
+import {TimelineActionTypes} from '../constants/';
+
+// For some reason, this can't use the normal import pattern.
+import BaseStore from '../utils/BaseStore.js';
 
 let teams = Immutable.Map();
 let currentSlug = null;

--- a/edwin/client/static/js/stores/UserStore.js
+++ b/edwin/client/static/js/stores/UserStore.js
@@ -10,8 +10,10 @@
 import Immutable from 'immutable';
 
 import Dispatcher from '../dispatcher';
-import BaseStore from '../utils/BaseStore';
-import UserActionTypes from '../constants/UserActionTypes.js';
+import {UserActionTypes} from '../constants/';
+
+// For some reason, this can't use the normal import pattern.
+import BaseStore from '../utils/BaseStore.js';
 
 let storeData = Immutable.fromJS({
   initialized: false,

--- a/edwin/client/static/js/stores/index.js
+++ b/edwin/client/static/js/stores/index.js
@@ -1,0 +1,13 @@
+import BugStore from './BugStore.js';
+import ProgressStore from './ProgressStore.js';
+import PRStore from './PRStore.js';
+import TeamStore from './TeamStore.js';
+import UserStore from './UserStore.js';
+
+export {
+    BugStore,
+    ProgressStore,
+    PRStore,
+    TeamStore,
+    UserStore
+};

--- a/edwin/client/static/js/utils/Cacher.js
+++ b/edwin/client/static/js/utils/Cacher.js
@@ -1,6 +1,7 @@
 import Immutable from 'immutable';
 import localForage from 'localforage';
 import _ from 'lodash';
+
 import Dispatcher from '../dispatcher.js';
 
 const CACHE_VERSION = 1;

--- a/edwin/client/static/js/utils/bzAPI.js
+++ b/edwin/client/static/js/utils/bzAPI.js
@@ -1,11 +1,12 @@
 import 'whatwg-fetch';
 import Immutable from 'immutable';
-import * as TimelineActions from '../actions/TimelineActions';
-import {buildUrl} from '../utils/urls';
 
 const fetch = window.fetch;
-const BUGZILLA_API = 'https://bugzilla.mozilla.org/rest';
 
+import {TimelineActions} from '../actions/';
+import {buildUrl} from '../utils/urls';
+
+const BUGZILLA_API = 'https://bugzilla.mozilla.org/rest';
 const fields = [
   'assigned_to',
   'blocks',

--- a/edwin/client/static/js/utils/edwinAPI.js
+++ b/edwin/client/static/js/utils/edwinAPI.js
@@ -1,9 +1,10 @@
 import 'whatwg-fetch';
 import Immutable from 'immutable';
-import * as TimelineActions from '../actions/TimelineActions';
-import {buildUrl} from '../utils/urls';
 
 const fetch = window.fetch;
+
+import {TimelineActions} from '../actions/';
+import {buildUrl} from '../utils/urls';
 
 /**
  * Make a call to the Edwin API.

--- a/edwin/client/static/js/utils/githubAPI.js
+++ b/edwin/client/static/js/utils/githubAPI.js
@@ -1,10 +1,11 @@
 import 'whatwg-fetch';
 import Immutable from 'immutable';
-import * as TimelineActions from '../actions/TimelineActions';
-import BugStore from '../stores/BugStore';
-import {buildUrl} from '../utils/urls';
 
 const fetch = window.fetch;
+
+import {TimelineActions} from '../actions/';
+import {buildUrl} from '../utils/urls';
+
 const GITHUB_API = 'https://api.github.com';
 
 /**

--- a/edwin/client/static/js/utils/index.js
+++ b/edwin/client/static/js/utils/index.js
@@ -1,0 +1,21 @@
+import BaseStore from './BaseStore.js';
+import bzAPI from './bzAPI.js';
+import Cacher from './Cacher.js';
+import ControllerComponent from './ControllerComponent.js';
+import edwinAPI from './edwinAPI.js';
+import githubAPI from './githubAPI.js';
+import parsers from './parsers.js';
+import PromiseExt from './PromiseExt.js';
+import urls from './urls.js';
+
+export {
+  BaseStore,
+  bzAPI,
+  Cacher,
+  ControllerComponent,
+  edwinAPI,
+  githubAPI,
+  parsers,
+  PromiseExt,
+  urls
+};

--- a/edwin/client/static/js/utils/parsers.js
+++ b/edwin/client/static/js/utils/parsers.js
@@ -75,3 +75,8 @@ export const bugReferences = PEG.buildParser(`
   int
     = digits:[0-9]+ { return parseInt(digits.join('')); }
 `);
+
+export default {
+  whiteboardData,
+  bugReferences,
+};

--- a/edwin/client/static/js/utils/urls.js
+++ b/edwin/client/static/js/utils/urls.js
@@ -24,3 +24,7 @@ export function buildUrl(base, endpoint, query={}) {
 
   return base + endpoint + qs;
 }
+
+export default {
+  buildUrl,
+};


### PR DESCRIPTION
A few didn't work with the new patter. Added comments to these. Maybe problems with circular imports or import order?

@willkg if you have any insights about the few that can't use this pattern, I'm really puzzled.

NB: Circular imports can work fine in ES6, with some caveats. In this way it is different from Python.
